### PR TITLE
Add the capability to wrap http.Handlers with CSRF verification.

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -1,0 +1,78 @@
+package charlie
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// HTTPParams provides configuration for wrapping an http.Handler
+// to check the validity of a CSRF token before permitting a request.
+type HTTPParams struct {
+	InvalidHandler http.Handler
+
+	Key []byte
+
+	CSRFCookie string
+	CSRFHeader string
+
+	SessionCookie string
+	SessionHeader string
+}
+
+// Wrap wraps an http.Handler to check the validity of a CSRF token.
+// It only serves requests where a valid ID/token pair can be found in
+// either the request headers or cookies. Otherwise, it calls the InvalidHandler
+// or returns an empty 403.
+func (hp *HTTPParams) Wrap(h http.Handler) http.Handler {
+	csrf := New(hp.Key)
+	csrf.MaxAge = 3 * time.Hour
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := headerOrCookieValue(r, hp.CSRFHeader, hp.CSRFCookie)
+		id := headerOrCookieValue(r, hp.SessionHeader, hp.SessionCookie)
+
+		var valid bool
+
+		if token != "" && id != "" {
+			err := csrf.Validate(id, token)
+			if err == nil {
+				valid = true
+			} else if err != ErrInvalidToken {
+				// This should never occur
+				panic(err)
+			}
+		}
+
+		if valid {
+			h.ServeHTTP(w, r)
+		} else if hp.InvalidHandler != nil {
+			hp.InvalidHandler.ServeHTTP(w, r)
+		} else {
+			log.Printf("Rejected request with an invalid CSRF token=%q for session=%q. (event=csrf_invalid)",
+				token, id)
+			w.WriteHeader(http.StatusForbidden)
+		}
+	})
+}
+
+func headerOrCookieValue(r *http.Request, headerName, cookieName string) string {
+	if headerName != "" {
+		token := r.Header.Get(headerName)
+		if token != "" {
+			return token
+		}
+	}
+
+	if cookieName != "" {
+		cookie, err := r.Cookie(cookieName)
+		if err == nil {
+			return cookie.Value
+		} else if err != http.ErrNoCookie {
+			// This should never occur
+			panic(err)
+		}
+	}
+
+	return ""
+}

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -1,0 +1,116 @@
+package charlie
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+const (
+	testCSRFHeader    = "csrf-hdr"
+	testCSRFCookie    = "csrf-ck"
+	testSessionHeader = "s-hdr"
+	testSessionCookie = "s-ck"
+	testKey           = "superdupersecret"
+	testSessionID     = "mysession"
+)
+
+var noContentHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(204)
+})
+
+func TestHTTPWrapping(t *testing.T) {
+	v := HTTPParams{
+		Key:           []byte(testKey),
+		CSRFHeader:    testCSRFHeader,
+		CSRFCookie:    testCSRFCookie,
+		SessionCookie: testSessionCookie,
+		SessionHeader: testSessionHeader,
+	}
+
+	csrf := New(v.Key)
+	token := csrf.Generate(testSessionID)
+
+	handler := v.Wrap(noContentHandler)
+
+	// Valid pair in cookies
+	req := http.Request{Header: http.Header{}}
+	req.AddCookie(&http.Cookie{
+		Name:    testCSRFCookie,
+		Value:   token,
+		Expires: time.Now().AddDate(10, 0, 0),
+	})
+	req.AddCookie(&http.Cookie{
+		Name:    testSessionCookie,
+		Value:   testSessionID,
+		Expires: time.Now().AddDate(10, 0, 0),
+	})
+
+	res := httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &req)
+	if res.Code != 204 {
+		t.Errorf("Expected to receive a 204 with correct CSRF token, got %d", res.Code)
+	}
+
+	// Valid pair in headers
+	hdr := http.Header{}
+	hdr.Set(testCSRFHeader, token)
+	hdr.Set(testSessionHeader, testSessionID)
+
+	res = httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &http.Request{Header: hdr})
+	if res.Code != 204 {
+		t.Fatalf("Expected to receive a 204 with correct CSRF token, got %d", res.Code)
+	}
+
+	// Incorrect session/token pair
+	hdr.Set(testSessionHeader, "notasession")
+
+	res = httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &http.Request{Header: hdr})
+	if res.Code != http.StatusForbidden {
+		t.Errorf("Expected to receive a 403 with an incorrect session, got %d", res.Code)
+	}
+
+	// Missing session header
+	hdr.Del(testSessionHeader)
+
+	res = httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &http.Request{Header: hdr})
+	if res.Code != http.StatusForbidden {
+		t.Errorf("Expected to receive a 403 with an incorrect session, got %d", res.Code)
+	}
+
+	// Custom InvalidHandler
+	v.InvalidHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(444)
+	})
+
+	res = httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &http.Request{Header: hdr})
+	if res.Code != 444 {
+		t.Errorf("Expected to receive a 444 with a custom handler, got %d", res.Code)
+	}
+}
+
+func TestHTTPWrappingMisconfiguration(t *testing.T) {
+	v := HTTPParams{}
+
+	handler := v.Wrap(noContentHandler)
+
+	res := httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &http.Request{})
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("Expected to receive a 403 without configuration, got %d", res.Code)
+	}
+
+	v.Key = []byte(testKey)
+
+	res = httptest.ResponseRecorder{}
+	handler.ServeHTTP(&res, &http.Request{})
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("Expected to receive a 403 with missing header/cookie configuration, got %d", res.Code)
+	}
+
+}


### PR DESCRIPTION
This adds the capability to wrap an HTTP handler to perform CSRF verification with every request. The goal is to facilitate the primary use-case for charlie: protecting particular endpoints of a web application.
