### PR TITLE
Prevent panic when validating empty token.

### DIFF
--- a/charlie.go
+++ b/charlie.go
@@ -62,7 +62,7 @@ func (p *Params) Generate(id string) string {
 // Validate validates the given token for the given user.
 func (p *Params) Validate(id, token string) error {
 	data, err := base64.URLEncoding.DecodeString(token)
-	if err != nil {
+	if err != nil || len(data) < dataSize+macSize {
 		return ErrInvalidToken
 	}
 

--- a/charlie_test.go
+++ b/charlie_test.go
@@ -48,6 +48,12 @@ func TestTokenLength(t *testing.T) {
 	}
 }
 
+func TestEmptyToken(t *testing.T) {
+	if err := params.Validate("woo", ""); err != ErrInvalidToken {
+		t.Errorf("Error was %v, but expected ErrInvalidToken", err)
+	}
+}
+
 func TestRoundTripConcurrent(t *testing.T) {
 	tokens := make(chan string, 100)
 


### PR DESCRIPTION
`Validate` panics with `runtime error: slice bounds out of range` when the token is successfully decoded from `base64` but isn't long enough to satisfy the slice operation. This PR fixes that. Still benchmarks under 4us for me.
